### PR TITLE
[Feat] Implement GNU `cut` in Go, with TDD

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,20 @@
+name: Test and coverage
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'cut/go.mod'
+          cache-dependency-path: cut/go.sum
+      - run: go run hello.go
+      - name: Run coverage
+        run:
+          cd cut
+          go test -v -race -coverprofile=coverage.txt -covermode=atomic
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -12,8 +12,8 @@ jobs:
           go-version-file: cut/go.mod
           cache-dependency-path: cut/go.sum
       - name: Run coverage
-        run:
-          cd cut
+        run: |
+          cd cut && \
           go test -v -race -coverprofile=coverage.txt -covermode=atomic
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -9,9 +9,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version-file: 'cut/go.mod'
+          go-version-file: cut/go.mod
           cache-dependency-path: cut/go.sum
-      - run: go run hello.go
       - name: Run coverage
         run:
           cd cut

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -17,3 +17,5 @@ jobs:
           go test -v -race -coverprofile=coverage.txt -covermode=atomic
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/cut/.vscode/launch.json
+++ b/cut/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${fileDirname}"
+        }
+    ]
+}

--- a/cut/README.md
+++ b/cut/README.md
@@ -1,0 +1,13 @@
+# Re-implementing GNU `cut` with Go
+
+## Testing
+
+Run the tests with
+```
+go test -v -coverprofile=coverage.out
+```
+
+Check coverage
+```
+go tool cover -html coverage.out
+```

--- a/cut/README.md
+++ b/cut/README.md
@@ -2,6 +2,139 @@
 
 [![codecov](https://codecov.io/github/philomathesinc/coreutils/branch/mbtamuli_cut_with_TDD/graph/badge.svg?token=PZD0YSY5SA)](https://codecov.io/github/philomathesinc/coreutils)
 
+## Scope
+
+- Iteratively work on the following.
+- Mark each point done after adding test cases.
+
+### Inputs
+- [x] Implement fields flag with delimiter - `--fields=LIST --delimiter=DELIM`
+- [ ] Implement characters flag - `--characters=LIST`
+- [ ] Implement bytes flag - `--bytes=LIST`
+
+### Outputs
+- [ ] Implement output delimiter - `--output-delimiter=STRING`
+- [ ] Implement output filtering - `--only-delimited`, `--complement`
+
+## References
+1. GNU `cut` Documentation
+    - https://www.gnu.org/software/coreutils/manual/html_node/cut-invocation.html
+    - https://www.gnu.org/software/coreutils/manual/html_node/The-cut-command.html
+2. Usage info via `cut --help`
+    ```
+    Usage: cut OPTION... [FILE]...
+    Print selected parts of lines from each FILE to standard output.
+
+    With no FILE, or when FILE is -, read standard input.
+
+    Mandatory arguments to long options are mandatory for short options too.
+    -b, --bytes=LIST        select only these bytes
+    -c, --characters=LIST   select only these characters
+    -d, --delimiter=DELIM   use DELIM instead of TAB for field delimiter
+    -f, --fields=LIST       select only these fields;  also print any line
+                                that contains no delimiter character, unless
+                                the -s option is specified
+    -n                      (ignored)
+        --complement        complement the set of selected bytes, characters
+                                or fields
+    -s, --only-delimited    do not print lines not containing delimiters
+        --output-delimiter=STRING  use STRING as the output delimiter
+                                the default is to use the input delimiter
+    -z, --zero-terminated    line delimiter is NUL, not newline
+        --help        display this help and exit
+        --version     output version information and exit
+
+    Use one, and only one of -b, -c or -f.  Each LIST is made up of one
+    range, or many ranges separated by commas.  Selected input is written
+    in the same order that it is read, and is written exactly once.
+    Each range is one of:
+
+    N     N'th byte, character or field, counted from 1
+    N-    from N'th byte, character or field, to end of line
+    N-M   from N'th to M'th (included) byte, character or field
+    -M    from first to M'th (included) byte, character or field
+
+    GNU coreutils online help: <https://www.gnu.org/software/coreutils/>
+    Full documentation <https://www.gnu.org/software/coreutils/cut>
+    or available locally via: info '(coreutils) cut invocation'
+    ```
+3. Man Page of GNU `cut`
+    ```
+    CUT(1)                                                             User Commands                                                            CUT(1)
+
+    NAME
+        cut - remove sections from each line of files
+
+    SYNOPSIS
+        cut OPTION... [FILE]...
+
+    DESCRIPTION
+        Print selected parts of lines from each FILE to standard output.
+
+        With no FILE, or when FILE is -, read standard input.
+
+        Mandatory arguments to long options are mandatory for short options too.
+
+        -b, --bytes=LIST
+                select only these bytes
+
+        -c, --characters=LIST
+                select only these characters
+
+        -d, --delimiter=DELIM
+                use DELIM instead of TAB for field delimiter
+
+        -f, --fields=LIST
+                select only these fields;  also print any line that contains no delimiter character, unless the -s option is specified
+
+        -n     (ignored)
+
+        --complement
+                complement the set of selected bytes, characters or fields
+
+        -s, --only-delimited
+                do not print lines not containing delimiters
+
+        --output-delimiter=STRING
+                use STRING as the output delimiter the default is to use the input delimiter
+
+        -z, --zero-terminated
+                line delimiter is NUL, not newline
+
+        --help display this help and exit
+
+        --version
+                output version information and exit
+
+        Use one, and only one of -b, -c or -f.  Each LIST is made up of one range, or many ranges separated by commas.  Selected input is written
+        in the same order that it is read, and is written exactly once.  Each range is one of:
+
+        N      N'th byte, character or field, counted from 1
+
+        N-     from N'th byte, character or field, to end of line
+
+        N-M    from N'th to M'th (included) byte, character or field
+
+        -M     from first to M'th (included) byte, character or field
+
+    AUTHOR
+        Written by David M. Ihnat, David MacKenzie, and Jim Meyering.
+
+    REPORTING BUGS
+        GNU coreutils online help: <https://www.gnu.org/software/coreutils/>
+        Report any translation bugs to <https://translationproject.org/team/>
+
+    COPYRIGHT
+        Copyright © 2023 Free Software Foundation, Inc.  License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
+        This is free software: you are free to change and redistribute it.  There is NO WARRANTY, to the extent permitted by law.
+
+    SEE ALSO
+        Full documentation <https://www.gnu.org/software/coreutils/cut>
+        or available locally via: info '(coreutils) cut invocation'
+
+    GNU coreutils 9.2                                                   March 2023                                                              CUT(1)
+    ```
+
 ## Testing
 
 Run the tests with

--- a/cut/README.md
+++ b/cut/README.md
@@ -1,6 +1,6 @@
 # Re-implementing GNU `cut` with Go
 
-[![codecov](https://codecov.io/github/philomathesinc/coreutils/branch/main/graph/badge.svg?token=PZD0YSY5SA)](https://codecov.io/github/philomathesinc/coreutils)
+[![codecov](https://codecov.io/github/philomathesinc/coreutils/branch/mbtamuli_cut_with_TDD/graph/badge.svg?token=PZD0YSY5SA)](https://codecov.io/github/philomathesinc/coreutils)
 
 ## Testing
 
@@ -13,3 +13,9 @@ Check coverage
 ```
 go tool cover -html coverage.out
 ```
+
+Current coverage
+
+<a href="https://codecov.io/github/philomathesinc/coreutils" >
+ <img src="https://codecov.io/github/philomathesinc/coreutils/branch/mbtamuli_cut_with_TDD/graphs/sunburst.svg?token=PZD0YSY5SA"/>
+</a>

--- a/cut/README.md
+++ b/cut/README.md
@@ -1,5 +1,7 @@
 # Re-implementing GNU `cut` with Go
 
+[![codecov](https://codecov.io/github/philomathesinc/coreutils/branch/main/graph/badge.svg?token=PZD0YSY5SA)](https://codecov.io/github/philomathesinc/coreutils)
+
 ## Testing
 
 Run the tests with

--- a/cut/cmd/main.go
+++ b/cut/cmd/main.go
@@ -1,7 +1,60 @@
 package main
 
-import "fmt"
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/philomathesinc/coreutils/cut"
+)
 
 func main() {
-	fmt.Println("call cut")
+	// Define flags
+	delimiterFlag := flag.String("d", "\t", "delimiter for fields")
+	fieldsFlag := flag.String("f", "", "fields or ranges to cut (ex. 1,3-5)")
+
+	flag.Parse()
+
+	// If no flags are passed, print usage
+	if flag.NFlag() == 0 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	files := flag.Args()
+
+	if flag.NArg() == 0 {
+		files = append(files, "-")
+	}
+
+	for _, filename := range files {
+		var (
+			file *os.File
+			err  error
+		)
+
+		if filename == "-" {
+			file = os.Stdin
+		} else {
+			file, err = os.Open(filename)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%s: No such file or directory", filename)
+			}
+			defer file.Close()
+		}
+
+		bytes, err := io.ReadAll(file)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to read file")
+		}
+
+		fields, err := cut.Fields(string(bytes), *fieldsFlag, *delimiterFlag)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+		}
+
+		fmt.Println(fields)
+
+	}
 }

--- a/cut/cmd/main.go
+++ b/cut/cmd/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("call cut")
+}

--- a/cut/cut.go
+++ b/cut/cut.go
@@ -1,0 +1,1 @@
+package cut

--- a/cut/cut.go
+++ b/cut/cut.go
@@ -48,10 +48,18 @@ func Fields(input, fields, delimiter string) (string, error) {
 		var (
 			output []string
 		)
+		finished := false
 		for _, r := range fRanges {
+			if finished {
+				break
+			}
 			// Count of cut starts from 1, so we need to subtract 1 from given field
 			startIndex := r.start - 1
 			endIndex := r.end
+
+			if endIndex == MaxInt {
+				finished = true
+			}
 
 			// Check if requested field is greater than the number of fields in the line
 			if startIndex > len(lFields) {

--- a/cut/cut.go
+++ b/cut/cut.go
@@ -7,7 +7,12 @@ import (
 )
 
 // Fields returns the requested field from the input, iterating over each line
-func Fields(input string, fields string) (string, error) {
+func Fields(input, fields, delimiter string) (string, error) {
+	// Delimiter is tab by default
+	if delimiter == "" {
+		delimiter = "\t"
+	}
+
 	// Variable to store output
 	var (
 		startStr, endStr string
@@ -57,7 +62,9 @@ func Fields(input string, fields string) (string, error) {
 	for _, line := range lines {
 
 		// Split line into fields
-		lFields := strings.Fields(line)
+		lFields := strings.FieldsFunc(line, func(r rune) bool {
+			return string(r) == delimiter
+		})
 
 		// Count of cut starts from 1, so we need to subtract 1 from given field
 		startIndex := start - 1
@@ -79,7 +86,7 @@ func Fields(input string, fields string) (string, error) {
 			endIndex = len(lFields)
 		}
 
-		output = append(output, strings.Join(lFields[startIndex:endIndex], "\t"))
+		output = append(output, strings.Join(lFields[startIndex:endIndex], delimiter))
 	}
 
 	// Join output with new line and return

--- a/cut/cut.go
+++ b/cut/cut.go
@@ -60,6 +60,11 @@ func Fields(input, fields, delimiter string) (string, error) {
 
 	// Iterate over lines
 	for _, line := range lines {
+		// If line doesn't contain delimiter, add it to output without any changes
+		if !strings.ContainsAny(line, delimiter) {
+			output = append(output, line)
+			continue
+		}
 
 		// Split line into fields
 		lFields := strings.FieldsFunc(line, func(r rune) bool {

--- a/cut/cut.go
+++ b/cut/cut.go
@@ -1,5 +1,19 @@
 package cut
 
+import (
+	"strconv"
+	"strings"
+)
+
 func Fields(input string, fields string) string {
-	return "b\nbb\nbbb"
+	var output []string
+	fieldNum, _ := strconv.Atoi(fields)
+	fieldIndex := fieldNum - 1
+	lines := strings.Split(input, "\n")
+	for _, line := range lines {
+		lFields := strings.Fields(line)
+		output = append(output, lFields[fieldIndex])
+	}
+
+	return strings.Join(output, "\n")
 }

--- a/cut/cut.go
+++ b/cut/cut.go
@@ -1,1 +1,5 @@
 package cut
+
+func Fields(input string, fields string) string {
+	return "b\nbb\nbbb"
+}

--- a/cut/cut.go
+++ b/cut/cut.go
@@ -6,21 +6,38 @@ import (
 	"strings"
 )
 
+// Fields returns the requested field from the input, iterating over each line
 func Fields(input string, fields string) (string, error) {
+	// Variable to store output
 	var output []string
+
+	// Convert fields to int
 	fieldNum, err := strconv.Atoi(fields)
 	if err != nil {
 		return "", errors.New("invalid field value")
 	}
+
+	// Split input into lines
 	lines := strings.Split(input, "\n")
+
+	// Iterate over lines
 	for _, line := range lines {
+
+		// Split line into fields
 		lFields := strings.Fields(line)
+
+		// Check if requested field is greater than the number of fields in the line
 		if fieldNum > len(lFields) {
 			continue
 		}
+
+		// Count of cut starts from 1, so we need to subtract 1 from given field
 		fieldIndex := fieldNum - 1
+
+		// Append field to output
 		output = append(output, lFields[fieldIndex])
 	}
 
+	// Join output with new line and return
 	return strings.Join(output, "\n"), nil
 }

--- a/cut/cut.go
+++ b/cut/cut.go
@@ -12,10 +12,13 @@ func Fields(input string, fields string) (string, error) {
 	if err != nil {
 		return "", errors.New("invalid field value")
 	}
-	fieldIndex := fieldNum - 1
 	lines := strings.Split(input, "\n")
 	for _, line := range lines {
 		lFields := strings.Fields(line)
+		if fieldNum > len(lFields) {
+			continue
+		}
+		fieldIndex := fieldNum - 1
 		output = append(output, lFields[fieldIndex])
 	}
 

--- a/cut/cut.go
+++ b/cut/cut.go
@@ -11,6 +11,7 @@ func Fields(input string, fields string) (string, error) {
 	// Variable to store output
 	var (
 		startStr, endStr string
+		start, end       int
 		output           []string
 	)
 
@@ -22,16 +23,30 @@ func Fields(input string, fields string) (string, error) {
 		endStr = requestedFieldParts[1]
 	}
 
+	if startStr == "" && endStr == "" {
+		return "", errors.New("invalid range with no endpoint")
+	}
+
+	if startStr == "" && endStr != "" {
+		startStr = "1"
+	}
+
 	start, err := strconv.Atoi(startStr)
 	if err != nil {
 		return "", errors.New("invalid field value")
 	}
-	end, err := strconv.Atoi(endStr)
-	if err != nil {
-		return "", errors.New("invalid field value")
+
+	if startStr != "" && endStr == "" {
+		endStr = "inf"
+		end = -1
+	} else {
+		end, err = strconv.Atoi(endStr)
+		if err != nil {
+			return "", errors.New("invalid field value")
+		}
 	}
 
-	if start < 1 || end < 1 {
+	if start < 1 || (end < 1 && end != -1) {
 		return "", errors.New("fields are numbered from 1")
 	}
 
@@ -44,14 +59,25 @@ func Fields(input string, fields string) (string, error) {
 		// Split line into fields
 		lFields := strings.Fields(line)
 
-		// Check if requested field is greater than the number of fields in the line
-		if end > len(lFields) {
-			continue
-		}
-
 		// Count of cut starts from 1, so we need to subtract 1 from given field
 		startIndex := start - 1
 		endIndex := end
+
+		// Check if requested field is greater than the number of fields in the line
+		if startIndex > len(lFields) {
+			output = append(output, "")
+			continue
+		}
+
+		if endIndex > len(lFields) {
+			output = append(output, "")
+			continue
+		}
+
+		// If endIndex is -1, it means we want to cut till the end of the line
+		if endIndex == -1 {
+			endIndex = len(lFields)
+		}
 
 		output = append(output, strings.Join(lFields[startIndex:endIndex], "\t"))
 	}

--- a/cut/cut.go
+++ b/cut/cut.go
@@ -1,13 +1,17 @@
 package cut
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 )
 
-func Fields(input string, fields string) string {
+func Fields(input string, fields string) (string, error) {
 	var output []string
-	fieldNum, _ := strconv.Atoi(fields)
+	fieldNum, err := strconv.Atoi(fields)
+	if err != nil {
+		return "", errors.New("invalid field value")
+	}
 	fieldIndex := fieldNum - 1
 	lines := strings.Split(input, "\n")
 	for _, line := range lines {
@@ -15,5 +19,5 @@ func Fields(input string, fields string) string {
 		output = append(output, lFields[fieldIndex])
 	}
 
-	return strings.Join(output, "\n")
+	return strings.Join(output, "\n"), nil
 }

--- a/cut/cut.go
+++ b/cut/cut.go
@@ -2,8 +2,14 @@ package cut
 
 import (
 	"errors"
+	"sort"
 	"strconv"
 	"strings"
+)
+
+const (
+	// https://go.dev/doc/effective_go#printing
+	MaxInt = int(^uint(0) >> 1) // largest int
 )
 
 // Fields returns the requested field from the input, iterating over each line
@@ -13,56 +19,23 @@ func Fields(input, fields, delimiter string) (string, error) {
 		delimiter = "\t"
 	}
 
-	// Variable to store output
-	var (
-		startStr, endStr string
-		start, end       int
-		output           []string
-	)
-
-	// Convert fields to int
-	requestedFieldParts := strings.Split(fields, "-")
-	startStr = requestedFieldParts[0]
-	endStr = startStr
-	if len(requestedFieldParts) == 2 {
-		endStr = requestedFieldParts[1]
-	}
-
-	if startStr == "" && endStr == "" {
-		return "", errors.New("invalid range with no endpoint")
-	}
-
-	if startStr == "" && endStr != "" {
-		startStr = "1"
-	}
-
-	start, err := strconv.Atoi(startStr)
+	// Get the field ranges
+	fRanges, err := fieldRanges(fields)
 	if err != nil {
-		return "", errors.New("invalid field value")
-	}
-
-	if startStr != "" && endStr == "" {
-		endStr = "inf"
-		end = -1
-	} else {
-		end, err = strconv.Atoi(endStr)
-		if err != nil {
-			return "", errors.New("invalid field value")
-		}
-	}
-
-	if start < 1 || (end < 1 && end != -1) {
-		return "", errors.New("fields are numbered from 1")
+		return "", err
 	}
 
 	// Split input into lines
 	lines := strings.Split(input, "\n")
 
+	// Slice of string for storing each line's requested fields
+	var finalOutput []string
+
 	// Iterate over lines
 	for _, line := range lines {
 		// If line doesn't contain delimiter, add it to output without any changes
 		if !strings.ContainsAny(line, delimiter) {
-			output = append(output, line)
+			finalOutput = append(finalOutput, line)
 			continue
 		}
 
@@ -71,29 +44,109 @@ func Fields(input, fields, delimiter string) (string, error) {
 			return string(r) == delimiter
 		})
 
-		// Count of cut starts from 1, so we need to subtract 1 from given field
-		startIndex := start - 1
-		endIndex := end
+		// Variable to store output for each line
+		var (
+			output []string
+		)
+		for _, r := range fRanges {
+			// Count of cut starts from 1, so we need to subtract 1 from given field
+			startIndex := r.start - 1
+			endIndex := r.end
 
-		// Check if requested field is greater than the number of fields in the line
-		if startIndex > len(lFields) {
-			output = append(output, "")
-			continue
+			// Check if requested field is greater than the number of fields in the line
+			if startIndex > len(lFields) {
+				continue
+			}
+
+			// If endIndex is MaxInt or greater than the number of fields present,
+			// it means we want to cut till the end of the line
+			if endIndex == MaxInt || endIndex > len(lFields) {
+				endIndex = len(lFields)
+			}
+
+			// Just add the requested fields to output
+			output = append(output, lFields[startIndex:endIndex]...)
 		}
 
-		if endIndex > len(lFields) {
-			output = append(output, "")
-			continue
-		}
-
-		// If endIndex is -1, it means we want to cut till the end of the line
-		if endIndex == -1 {
-			endIndex = len(lFields)
-		}
-
-		output = append(output, strings.Join(lFields[startIndex:endIndex], delimiter))
+		// Join all the fields of a single line with the delimiter
+		finalOutput = append(finalOutput, strings.Join(output, delimiter))
 	}
 
-	// Join output with new line and return
-	return strings.Join(output, "\n"), nil
+	// For the final output, join each item in finalOutput with a newline
+	return strings.Join(finalOutput, "\n"), nil
+}
+
+type fRange struct {
+	start int
+	end   int
+}
+
+func fieldRanges(f string) ([]fRange, error) {
+	fieldRangesOutput := []fRange{}
+
+	// Split all field ranges
+	givenfieldRanges := strings.Split(f, ",")
+
+	for _, fieldRange := range givenfieldRanges {
+		var (
+			startStr, endStr string
+			start, end       int
+		)
+
+		// Split the range on `-`
+		before, after, found := strings.Cut(fieldRange, "-")
+
+		startStr = before
+		endStr = after
+
+		// If no `-`, that means it's not a range but a single field
+		if !found {
+			endStr = before
+		}
+
+		// If the field is passed as just `-`
+		if startStr == "" && endStr == "" {
+			return fieldRangesOutput, errors.New("invalid range with no endpoint")
+		}
+
+		// If the field is passed as `-X`, then consider the field as `1-X`
+		if startStr == "" && endStr != "" {
+			startStr = "1"
+		}
+
+		// If the field is passed as `X-`, then set end as MaxInt
+		if startStr != "" && endStr == "" {
+			endStr = strconv.Itoa(MaxInt)
+		}
+
+		// Convert to int
+		start, err := strconv.Atoi(startStr)
+		if err != nil {
+			return fieldRangesOutput, errors.New("invalid field value")
+		}
+
+		// Convert to int
+		end, err = strconv.Atoi(endStr)
+		if err != nil {
+			return fieldRangesOutput, errors.New("invalid field value")
+		}
+
+		// Field number can't be lower than 1
+		if start < 1 || end < 1 {
+			return fieldRangesOutput, errors.New("fields are numbered from 1")
+		}
+
+		fieldRangesOutput = append(fieldRangesOutput, fRange{
+			start,
+			end,
+		})
+
+	}
+
+	// We want the output to be in order
+	sort.Slice(fieldRangesOutput, func(i, j int) bool {
+		return fieldRangesOutput[i].start < fieldRangesOutput[j].start
+	})
+
+	return fieldRangesOutput, nil
 }

--- a/cut/cut.go
+++ b/cut/cut.go
@@ -9,10 +9,24 @@ import (
 // Fields returns the requested field from the input, iterating over each line
 func Fields(input string, fields string) (string, error) {
 	// Variable to store output
-	var output []string
+	var (
+		startStr, endStr string
+		output           []string
+	)
 
 	// Convert fields to int
-	fieldNum, err := strconv.Atoi(fields)
+	requestedFieldParts := strings.Split(fields, "-")
+	startStr = requestedFieldParts[0]
+	endStr = startStr
+	if len(requestedFieldParts) == 2 {
+		endStr = requestedFieldParts[1]
+	}
+
+	start, err := strconv.Atoi(startStr)
+	if err != nil {
+		return "", errors.New("invalid field value")
+	}
+	end, err := strconv.Atoi(endStr)
 	if err != nil {
 		return "", errors.New("invalid field value")
 	}
@@ -27,15 +41,21 @@ func Fields(input string, fields string) (string, error) {
 		lFields := strings.Fields(line)
 
 		// Check if requested field is greater than the number of fields in the line
-		if fieldNum > len(lFields) {
+		if end > len(lFields) {
 			continue
 		}
 
 		// Count of cut starts from 1, so we need to subtract 1 from given field
-		fieldIndex := fieldNum - 1
+		startIndex := start - 1
+		endIndex := end
 
 		// Append field to output
-		output = append(output, lFields[fieldIndex])
+		if startIndex == endIndex {
+			output = append(output, lFields[startIndex])
+			continue
+		}
+
+		output = append(output, strings.Join(lFields[startIndex:endIndex], "\t"))
 	}
 
 	// Join output with new line and return

--- a/cut/cut.go
+++ b/cut/cut.go
@@ -31,6 +31,10 @@ func Fields(input string, fields string) (string, error) {
 		return "", errors.New("invalid field value")
 	}
 
+	if start < 1 || end < 1 {
+		return "", errors.New("fields are numbered from 1")
+	}
+
 	// Split input into lines
 	lines := strings.Split(input, "\n")
 
@@ -48,12 +52,6 @@ func Fields(input string, fields string) (string, error) {
 		// Count of cut starts from 1, so we need to subtract 1 from given field
 		startIndex := start - 1
 		endIndex := end
-
-		// Append field to output
-		if startIndex == endIndex {
-			output = append(output, lFields[startIndex])
-			continue
-		}
 
 		output = append(output, strings.Join(lFields[startIndex:endIndex], "\t"))
 	}

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -49,9 +49,9 @@ func noDelimiters(t *testing.T) func(t *testing.T) {
 				"field not present",
 				args{
 					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
-					"3-3",
+					"5",
 				},
-				"cc\nccc",
+				"\n\n",
 				false,
 			},
 			{
@@ -82,7 +82,7 @@ func noDelimiters(t *testing.T) func(t *testing.T) {
 					return
 				}
 				if got != tt.want {
-					t.Errorf("Fields() = %v, want %v", got, tt.want)
+					t.Errorf("Fields() mismatch (-want +got):\n%s", cmp.Diff(tt.want, got))
 				}
 			})
 		}
@@ -112,6 +112,15 @@ func variousRanges(t *testing.T) func(t *testing.T) {
 				},
 				"a	b\naa	bb\naaa	bbb",
 				false,
+			},
+			{
+				"invalid range with no endpoint",
+				args{
+					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
+					"-",
+				},
+				"",
+				true,
 			},
 			{
 				"start incorrect for range",

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -9,11 +9,13 @@ import (
 func TestFields(t *testing.T) {
 	t.Run("No delimiter", func(t *testing.T) {
 		fieldsTests := []struct {
+			name   string
 			input  string
 			fields string
 			want   string
 		}{
 			{
+				"letters",
 				`a:b
 aa:bb:cc
 aaa:bbb:ccc:ddd`,
@@ -23,6 +25,7 @@ bb
 bbb`,
 			},
 			{
+				"numbers",
 				`1:2
 11:22:33
 111:222:333:444`,
@@ -34,12 +37,14 @@ bbb`,
 		}
 
 		for _, tt := range fieldsTests {
-			got := cut.Fields(tt.input, tt.fields)
-			want := tt.want
+			t.Run(tt.name, func(t *testing.T) {
+				got := cut.Fields(tt.input, tt.fields)
+				want := tt.want
 
-			if got != want {
-				t.Errorf("got %q want %q", got, want)
-			}
+				if got != want {
+					t.Errorf("got %q want %q", got, want)
+				}
+			})
 		}
 	})
 }

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -16,9 +16,9 @@ func TestFields(t *testing.T) {
 		}{
 			{
 				"letters",
-				`a:b
-aa:bb:cc
-aaa:bbb:ccc:ddd`,
+				`a	b
+aa	bb	cc
+aaa	bbb	ccc	ddd`,
 				"2",
 				`b
 bb
@@ -26,9 +26,9 @@ bbb`,
 			},
 			{
 				"numbers",
-				`1:2
-11:22:33
-111:222:333:444`,
+				`1	2
+11	22	33
+111	222	333	444`,
 				"2",
 				`2
 22

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestFields(t *testing.T) {
 	t.Run("No delimiter", noDelimiters(t))
+	t.Run("Various ranges", variousRanges(t))
 }
 
 func noDelimiters(t *testing.T) func(t *testing.T) {
@@ -68,6 +69,47 @@ func noDelimiters(t *testing.T) func(t *testing.T) {
 					"2",
 				},
 				"2",
+				false,
+			},
+		}
+
+		for _, tt := range fieldsTests {
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := cut.Fields(tt.args.input, tt.args.fields)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("Fields() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				if got != tt.want {
+					t.Errorf("Fields() = %v, want %v", got, tt.want)
+				}
+			})
+		}
+	}
+}
+
+func variousRanges(t *testing.T) func(t *testing.T) {
+	t.Helper()
+
+	return func(t *testing.T) {
+		type args struct {
+			input  string
+			fields string
+		}
+
+		fieldsTests := []struct {
+			name    string
+			args    args
+			want    string
+			wantErr bool
+		}{
+			{
+				"letters",
+				args{
+					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
+					"1-2",
+				},
+				"a	b\naa	bb\naaa	bbb",
 				false,
 			},
 		}

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -1,0 +1,22 @@
+package cut_test
+
+import (
+	"testing"
+)
+
+func TestFields(t *testing.T) {
+	t.Run("No delimiter", func(t *testing.T) {
+		got := cut.Fields(`a:b
+		aa:bb:cc
+		aaa:bbb:ccc:ddd
+		`, "2")
+		want := `b
+		bb
+		bbb
+		`
+
+		if got != want {
+			t.Errorf("got %q want %q", got, want)
+		}
+	})
+}

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -61,6 +61,15 @@ func noDelimiters(t *testing.T) func(t *testing.T) {
 				"33\n333",
 				false,
 			},
+			{
+				"no newline in input",
+				args{
+					"1	2",
+					"2",
+				},
+				"2",
+				false,
+			},
 		}
 
 		for _, tt := range fieldsTests {

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -251,10 +251,10 @@ func multipleRanges(t *testing.T) func(t *testing.T) {
 			{
 				"happy path",
 				args{
-					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
-					"1,3",
+					"a	b	c	d\naa	bb	cc	dd	ee\naaa	bbb	ccc	ddd	eee	fff",
+					"1-2,4-5",
 				},
-				"a\naa	cc\naaa	ccc",
+				"a	b	d\naa	bb	dd	ee\naaa	bbb	ddd	eee",
 				false,
 			},
 		}

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -211,7 +211,7 @@ func delimiterSpecified(t *testing.T) func(t *testing.T) {
 					"1-2",
 					":",
 				},
-				"a:b\naa:bb\naaa:bbb",
+				"a	b\naa	bb	cc\naaa:bbb",
 				false,
 			},
 		}

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -7,7 +7,13 @@ import (
 )
 
 func TestFields(t *testing.T) {
-	t.Run("No delimiter", func(t *testing.T) {
+	t.Run("No delimiter", noDelimiters(t))
+}
+
+func noDelimiters(t *testing.T) func(t *testing.T) {
+	t.Helper()
+
+	return func(t *testing.T) {
 		type args struct {
 			input  string
 			fields string
@@ -22,35 +28,25 @@ func TestFields(t *testing.T) {
 			{
 				"letters",
 				args{
-					`a	b
-aa	bb	cc
-aaa	bbb	ccc	ddd`,
+					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
 					"2",
 				},
-				`b
-bb
-bbb`,
+				"b\nbb\nbbb",
 				false,
 			},
 			{
 				"numbers",
 				args{
-					`1	2
-11	22	33
-111	222	333	444`,
+					"1	2\n11	22	33\n111	222	333	444",
 					"2",
 				},
-				`2
-22
-222`,
+				"2\n22\n222",
 				false,
 			},
 			{
 				"unacceptable fields",
 				args{
-					`1	2
- 11	22	33
- 111	222	333	444`,
+					"1	2\n11	22	33\n111	222	333	444",
 					"a",
 				},
 				"",
@@ -70,5 +66,5 @@ bbb`,
 				}
 			})
 		}
-	})
+	}
 }

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -8,15 +8,29 @@ import (
 
 func TestFields(t *testing.T) {
 	t.Run("No delimiter", func(t *testing.T) {
-		got := cut.Fields(`a:b
+		fieldsTests := []struct {
+			input  string
+			fields string
+			want   string
+		}{
+			{
+				`a:b
 aa:bb:cc
-aaa:bbb:ccc:ddd`, "2")
-		want := `b
+aaa:bbb:ccc:ddd`,
+				"2",
+				`b
 bb
-bbb`
+bbb`,
+			},
+		}
 
-		if got != want {
-			t.Errorf("got %q want %q", got, want)
+		for _, tt := range fieldsTests {
+			got := cut.Fields(tt.input, tt.fields)
+			want := tt.want
+
+			if got != want {
+				t.Errorf("got %q want %q", got, want)
+			}
 		}
 	})
 }

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -8,41 +8,65 @@ import (
 
 func TestFields(t *testing.T) {
 	t.Run("No delimiter", func(t *testing.T) {
-		fieldsTests := []struct {
-			name   string
+		type args struct {
 			input  string
 			fields string
-			want   string
+		}
+
+		fieldsTests := []struct {
+			name    string
+			args    args
+			want    string
+			wantErr bool
 		}{
 			{
 				"letters",
-				`a	b
+				args{
+					`a	b
 aa	bb	cc
 aaa	bbb	ccc	ddd`,
-				"2",
+					"2",
+				},
 				`b
 bb
 bbb`,
+				false,
 			},
 			{
 				"numbers",
-				`1	2
+				args{
+					`1	2
 11	22	33
 111	222	333	444`,
-				"2",
+					"2",
+				},
 				`2
 22
 222`,
+				false,
+			},
+			{
+				"unacceptable fields",
+				args{
+					`1	2
+ 11	22	33
+ 111	222	333	444`,
+					"a",
+				},
+				"",
+				true,
 			},
 		}
 
 		for _, tt := range fieldsTests {
 			t.Run(tt.name, func(t *testing.T) {
-				got := cut.Fields(tt.input, tt.fields)
-				want := tt.want
-
-				if got != want {
-					t.Errorf("got %q want %q", got, want)
+				got, err := cut.Fields(tt.args.input, tt.args.fields)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("Fields() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				if got != tt.want {
+					t.Errorf("Fields() = %v, want %v", got, tt.want)
 				}
 			})
 		}

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -204,6 +204,16 @@ func delimiterSpecified(t *testing.T) func(t *testing.T) {
 				"a:b\naa:bb\naaa:bbb",
 				false,
 			},
+			{
+				"mixed delimiters in input",
+				args{
+					"a	b\naa	bb	cc\naaa:bbb:ccc:ddd",
+					"1-2",
+					":",
+				},
+				"a:b\naa:bb\naaa:bbb",
+				false,
+			},
 		}
 
 		for _, tt := range fieldsTests {

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -11,7 +11,7 @@ func TestFields(t *testing.T) {
 	t.Run("No delimiter", noDelimiters(t))
 	t.Run("Types of ranges", typesOfRanges(t))
 	t.Run("Delimiter specified", delimiterSpecified(t))
-	// t.Run("Multiple ranges", multipleRanges(t))
+	t.Run("Multiple ranges", multipleRanges(t))
 }
 
 func noDelimiters(t *testing.T) func(t *testing.T) {
@@ -215,11 +215,63 @@ func delimiterSpecified(t *testing.T) func(t *testing.T) {
 				"a	b\naa	bb	cc\naaa:bbb",
 				false,
 			},
+			{
+				"mixed delimiters in input",
+				args{
+					"a	b\naa	bb	cc\naaa:bbb:ccc:ddd",
+					"1-2",
+					":",
+				},
+				"a	b\naa	bb	cc\naaa:bbb",
+				false,
+			},
 		}
 
 		for _, tt := range fieldsTests {
 			t.Run(tt.name, func(t *testing.T) {
 				got, err := cut.Fields(tt.args.input, tt.args.fields, tt.args.delimiter)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("Fields() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				diff := cmp.Diff(tt.want, got)
+				if diff != "" {
+					t.Errorf("Fields() mismatch (-want +got):\n%+v", diff)
+				}
+			})
+		}
+	}
+}
+
+func multipleRanges(t *testing.T) func(t *testing.T) {
+	t.Helper()
+
+	return func(t *testing.T) {
+		type args struct {
+			input  string
+			fields string
+		}
+
+		fieldsTests := []struct {
+			name    string
+			args    args
+			want    string
+			wantErr bool
+		}{
+			{
+				"happy path",
+				args{
+					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
+					"1,3",
+				},
+				"a\naa	cc\naaa	ccc",
+				false,
+			},
+		}
+
+		for _, tt := range fieldsTests {
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := cut.Fields(tt.args.input, tt.args.fields, "")
 				if (err != nil) != tt.wantErr {
 					t.Errorf("Fields() error = %v, wantErr %v", err, tt.wantErr)
 					return

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -27,7 +27,7 @@ func noDelimiters(t *testing.T) func(t *testing.T) {
 			wantErr bool
 		}{
 			{
-				"letters",
+				"happy path",
 				args{
 					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
 					"2",
@@ -36,40 +36,40 @@ func noDelimiters(t *testing.T) func(t *testing.T) {
 				false,
 			},
 			{
-				"numbers",
-				args{
-					"1	2\n11	22	33\n111	222	333	444",
-					"2",
-				},
-				"2\n22\n222",
-				false,
-			},
-			{
 				"unacceptable fields",
 				args{
-					"1	2\n11	22	33\n111	222	333	444",
+					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
 					"a",
 				},
 				"",
 				true,
 			},
 			{
-				"field not present in all lines",
+				"field not present",
 				args{
-					"1	2\n11	22	33\n111	222	333	444",
-					"3",
+					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
+					"3-3",
 				},
-				"33\n333",
+				"cc\nccc",
 				false,
 			},
 			{
-				"no newline in input",
+				"field not present in all lines",
 				args{
-					"1	2",
-					"2",
+					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
+					"3",
 				},
-				"2",
+				"cc\nccc",
 				false,
+			},
+			{
+				"field less than 1",
+				args{
+					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
+					"0",
+				},
+				"",
+				true,
 			},
 		}
 
@@ -104,13 +104,31 @@ func variousRanges(t *testing.T) func(t *testing.T) {
 			wantErr bool
 		}{
 			{
-				"letters",
+				"happy path",
 				args{
 					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
 					"1-2",
 				},
 				"a	b\naa	bb\naaa	bbb",
 				false,
+			},
+			{
+				"start incorrect for range",
+				args{
+					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
+					"a-3",
+				},
+				"",
+				true,
+			},
+			{
+				"end incorrect for range",
+				args{
+					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
+					"1-a",
+				},
+				"",
+				true,
 			},
 		}
 

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -52,6 +52,15 @@ func noDelimiters(t *testing.T) func(t *testing.T) {
 				"",
 				true,
 			},
+			{
+				"field not present in all lines",
+				args{
+					"1	2\n11	22	33\n111	222	333	444",
+					"3",
+				},
+				"33\n333",
+				false,
+			},
 		}
 
 		for _, tt := range fieldsTests {

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -22,6 +22,15 @@ aaa:bbb:ccc:ddd`,
 bb
 bbb`,
 			},
+			{
+				`1:2
+11:22:33
+111:222:333:444`,
+				"2",
+				`2
+22
+222`,
+			},
 		}
 
 		for _, tt := range fieldsTests {

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -215,16 +215,6 @@ func delimiterSpecified(t *testing.T) func(t *testing.T) {
 				"a	b\naa	bb	cc\naaa:bbb",
 				false,
 			},
-			{
-				"mixed delimiters in input",
-				args{
-					"a	b\naa	bb	cc\naaa:bbb:ccc:ddd",
-					"1-2",
-					":",
-				},
-				"a	b\naa	bb	cc\naaa:bbb",
-				false,
-			},
 		}
 
 		for _, tt := range fieldsTests {

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -2,18 +2,18 @@ package cut_test
 
 import (
 	"testing"
+
+	"github.com/philomathesinc/coreutils/cut"
 )
 
 func TestFields(t *testing.T) {
 	t.Run("No delimiter", func(t *testing.T) {
 		got := cut.Fields(`a:b
-		aa:bb:cc
-		aaa:bbb:ccc:ddd
-		`, "2")
+aa:bb:cc
+aaa:bbb:ccc:ddd`, "2")
 		want := `b
-		bb
-		bbb
-		`
+bb
+bbb`
 
 		if got != want {
 			t.Errorf("got %q want %q", got, want)

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -10,6 +10,7 @@ import (
 func TestFields(t *testing.T) {
 	t.Run("No delimiter", noDelimiters(t))
 	t.Run("Various ranges", variousRanges(t))
+	t.Run("Delimiter specified", delimiterSpecified(t))
 }
 
 func noDelimiters(t *testing.T) func(t *testing.T) {
@@ -163,6 +164,49 @@ func variousRanges(t *testing.T) func(t *testing.T) {
 		for _, tt := range fieldsTests {
 			t.Run(tt.name, func(t *testing.T) {
 				got, err := cut.Fields(tt.args.input, tt.args.fields)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("Fields() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				if got != tt.want {
+					t.Errorf("Fields() mismatch (-want +got):\n%s", cmp.Diff(tt.want, got))
+				}
+			})
+		}
+	}
+}
+
+func delimiterSpecified(t *testing.T) func(t *testing.T) {
+	t.Helper()
+
+	return func(t *testing.T) {
+		type args struct {
+			input     string
+			fields    string
+			delimiter string
+		}
+
+		fieldsTests := []struct {
+			name    string
+			args    args
+			want    string
+			wantErr bool
+		}{
+			{
+				"happy path",
+				args{
+					"a:b\naa:bb:cc\naaa:bbb:ccc:ddd",
+					"1-2",
+					":",
+				},
+				"a:b\naa:bb\naaa:bbb",
+				false,
+			},
+		}
+
+		for _, tt := range fieldsTests {
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := cut.Fields(tt.args.input, tt.args.fields, tt.args.delimiter)
 				if (err != nil) != tt.wantErr {
 					t.Errorf("Fields() error = %v, wantErr %v", err, tt.wantErr)
 					return

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -77,13 +77,14 @@ func noDelimiters(t *testing.T) func(t *testing.T) {
 
 		for _, tt := range fieldsTests {
 			t.Run(tt.name, func(t *testing.T) {
-				got, err := cut.Fields(tt.args.input, tt.args.fields)
+				got, err := cut.Fields(tt.args.input, tt.args.fields, "")
 				if (err != nil) != tt.wantErr {
 					t.Errorf("Fields() error = %v, wantErr %v", err, tt.wantErr)
 					return
 				}
-				if got != tt.want {
-					t.Errorf("Fields() mismatch (-want +got):\n%s", cmp.Diff(tt.want, got))
+				diff := cmp.Diff(tt.want, got)
+				if diff != "" {
+					t.Errorf("Fields() mismatch (-want +got):\n%+v", diff)
 				}
 			})
 		}
@@ -163,13 +164,14 @@ func variousRanges(t *testing.T) func(t *testing.T) {
 
 		for _, tt := range fieldsTests {
 			t.Run(tt.name, func(t *testing.T) {
-				got, err := cut.Fields(tt.args.input, tt.args.fields)
+				got, err := cut.Fields(tt.args.input, tt.args.fields, "")
 				if (err != nil) != tt.wantErr {
 					t.Errorf("Fields() error = %v, wantErr %v", err, tt.wantErr)
 					return
 				}
-				if got != tt.want {
-					t.Errorf("Fields() mismatch (-want +got):\n%s", cmp.Diff(tt.want, got))
+				diff := cmp.Diff(tt.want, got)
+				if diff != "" {
+					t.Errorf("Fields() mismatch (-want +got):\n%+v", diff)
 				}
 			})
 		}
@@ -211,8 +213,9 @@ func delimiterSpecified(t *testing.T) func(t *testing.T) {
 					t.Errorf("Fields() error = %v, wantErr %v", err, tt.wantErr)
 					return
 				}
-				if got != tt.want {
-					t.Errorf("Fields() mismatch (-want +got):\n%s", cmp.Diff(tt.want, got))
+				diff := cmp.Diff(tt.want, got)
+				if diff != "" {
+					t.Errorf("Fields() mismatch (-want +got):\n%+v", diff)
 				}
 			})
 		}

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -3,6 +3,7 @@ package cut_test
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/philomathesinc/coreutils/cut"
 )
 
@@ -59,7 +60,7 @@ func noDelimiters(t *testing.T) func(t *testing.T) {
 					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
 					"3",
 				},
-				"cc\nccc",
+				"\ncc\nccc",
 				false,
 			},
 			{
@@ -130,6 +131,24 @@ func variousRanges(t *testing.T) func(t *testing.T) {
 				"",
 				true,
 			},
+			{
+				"start only range",
+				args{
+					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
+					"3-",
+				},
+				"\ncc\nccc	ddd",
+				false,
+			},
+			{
+				"end only range",
+				args{
+					"a	b\naa	bb	cc\naaa	bbb	ccc	ddd",
+					"-2",
+				},
+				"a	b\naa	bb\naaa	bbb",
+				false,
+			},
 		}
 
 		for _, tt := range fieldsTests {
@@ -140,7 +159,7 @@ func variousRanges(t *testing.T) func(t *testing.T) {
 					return
 				}
 				if got != tt.want {
-					t.Errorf("Fields() = %v, want %v", got, tt.want)
+					t.Errorf("Fields() mismatch (-want +got):\n%s", cmp.Diff(tt.want, got))
 				}
 			})
 		}

--- a/cut/cut_test.go
+++ b/cut/cut_test.go
@@ -9,8 +9,9 @@ import (
 
 func TestFields(t *testing.T) {
 	t.Run("No delimiter", noDelimiters(t))
-	t.Run("Various ranges", variousRanges(t))
+	t.Run("Types of ranges", typesOfRanges(t))
 	t.Run("Delimiter specified", delimiterSpecified(t))
+	// t.Run("Multiple ranges", multipleRanges(t))
 }
 
 func noDelimiters(t *testing.T) func(t *testing.T) {
@@ -91,7 +92,7 @@ func noDelimiters(t *testing.T) func(t *testing.T) {
 	}
 }
 
-func variousRanges(t *testing.T) func(t *testing.T) {
+func typesOfRanges(t *testing.T) func(t *testing.T) {
 	t.Helper()
 
 	return func(t *testing.T) {

--- a/cut/go.mod
+++ b/cut/go.mod
@@ -1,0 +1,3 @@
+module github.com/philomathesinc/coreutils/cut
+
+go 1.20

--- a/cut/go.mod
+++ b/cut/go.mod
@@ -1,3 +1,5 @@
 module github.com/philomathesinc/coreutils/cut
 
 go 1.20
+
+require github.com/google/go-cmp v0.5.9

--- a/cut/go.sum
+++ b/cut/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
Signed-off-by: Mriyam Tamuli <mbtamuli@gmail.com>

## Manual Testing
```sh
➜ cat input
a	b	c	d               ## Tab separators
aa:bb:cc:dd:ee
aaa	bbb	ccc:ddd:eee:fff%    ## No newline, tabs between first 3 fields
➜ cut -f "1,3-4" -d ":" input
a	b	c	d
aa:cc:dd
aaa	bbb	ccc:eee:fff
➜ ./cut -f "1,3-4" -d ":" input
a	b	c	d
aa:cc:dd
aaa	bbb	ccc:eee:fff
➜ cat input | cut -f "1,3-4" -d ":" -
a	b	c	d
aa:cc:dd
aaa	bbb	ccc:eee:fff
➜ cat input | ./cut -f "1,3-4" -d ":" -
a	b	c	d
aa:cc:dd
aaa	bbb	ccc:eee:fff
➜ cat input | cut -f "1,3-4" -d ":"
a	b	c	d
aa:cc:dd
aaa	bbb	ccc:eee:fff
➜ cat input | ./cut -f "1,3-4" -d ":"
a	b	c	d
aa:cc:dd
aaa	bbb	ccc:eee:fff
```
